### PR TITLE
scripts: avoid "unbound variable" errors

### DIFF
--- a/scripts/attach-disk.sh
+++ b/scripts/attach-disk.sh
@@ -9,15 +9,15 @@
 # Usage: attach-disk.sh <node> [disk_dir_domain]
 #
 
-NODE=$1
-SIZE=30
-
-if [ -z $NODE ]; then
+if [ "$#" -lt 1 ]; then
   echo "Usage: $0 <node> [disk_dir_domain]"
   exit 1
 fi
 
-if [ -z $2 ]; then
+NODE=$1
+SIZE=30
+
+if [ "$#" -lt 2 ]; then
   DISKS_DIR=/tmp/hotplug_disks
 else
   DISKS_DIR=/tmp/hotplug_disks/$2


### PR DESCRIPTION
Because this script is run with `set -u`, it will abort when referencing variables that are unset, e.g.:

```
./scripts/attach-disk.sh node1
+ NODE=node1
+ SIZE=30
+ '[' -z node1 ']' ./scripts/attach-disk.sh: line 20: $2: unbound variable
```

We can avoid this by checking the number of parameters via `"$#"` in advance.